### PR TITLE
Makes email consistent

### DIFF
--- a/our_work/index.md
+++ b/our_work/index.md
@@ -18,4 +18,4 @@ Our projects involve just the type of public-private cooperation that the strate
 
 Our team works fast, in the open, and with Joint Venture Partners. We adhere to the highest privacy and security standards: We support only trusted data networks; we follow rigorous privacy and security guidelines.
 
-Do you have a project in mind? Let us know: <a href="mailto:info@ntis.gov?Subject=Project%20Inquiry" target="_top"> info@ntis.gov</a>. We'll respond within 24 hours. 
+Do you have a project in mind? <a href="mailto:info@ntis.gov?Subject=Project%20Inquiry" target="_top">Reach out to us</a>. We'll respond within 24 hours. 


### PR DESCRIPTION
This makes the call to action consistent on the "Our work" and "Partner with us" pages.

cc @femmebot @OpenGlobe 
