### PR TITLE
Final content audit

### DIFF
--- a/about_us/index.md
+++ b/about_us/index.md
@@ -10,7 +10,7 @@ summary: Transforming data into valuable public services
 
 We're part of &ldquo;America’s Data Agency,&rdquo; the Department of Commerce.
 
-We help federal agencies make better decisions about data, with data. We provide the support and structure that helps our partners securely store, analyze, sort, and aggregate data in new ways. We use our private-sector partners' knowledge to create new ways of using data to solve problems. Our Joint Venture program works side-by-side with universities, nonprofits and industry professionals --- together, they can experiment with data science technologies before they’re available in the marketplace.
+We help federal agencies make better decisions about data, with data. We provide the support and structure that helps our partners securely store, analyze, sort, and aggregate data in new ways. We use our private-sector partners' knowledge to create new ways of using data to solve problems. 
 
 ### Our history
 

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
           When a government agency needs help analyzing, publishing, or managing its data, we use a special authority&mdash;<a href="http://www.ntis.gov/services/jvpannounce/">Joint Venture Authority</a>&mdash; (JV Authority) to pair them with experts from the private sector. That means agencies work side-by-side with universities, nonprofits, and private-industry professionals. Together, we solve problems and build solutions.
         </p>
 
-        <h3>Partner with us</h3>
+        <h3>Who we work with</h3>
         <h4>Government agencies</h4>
         <p>
           Put your data to good use. We can connect you with other federal and private-sector data providers. Focus on your mission and let us handle the infrastructure.  We&rsquo;ll pair you with experts who will bring insight and innovation to your project. They&rsquo;ll help you create new products and services. All we need to get started is an interagency agreement or a memorandum of understanding.
@@ -83,9 +83,9 @@
 
       <nav class="links">
         <p>
-          Learn more: <a href="about_us/index.html">About us</a> /
-          Get details about <a href="our_work/index.html">Our work</a>: What we do, Our process, and Case studies /
-          Let&rsquo;s work together: <a href="partner/index.html">Partner with us</a>
+          Learn more <a href="about_us/index.html">about us</a> /
+          Get details about <a href="our_work/index.html">our work</a>, including our process and case studies /
+          Become a federal or private-sector <a href="partner/index.html">partner</a>
         </p>
       </nav>
 

--- a/our_work/index.md
+++ b/our_work/index.md
@@ -11,7 +11,7 @@ With the support of industry experts, we help federal agencies manage data and c
 
 The [Federal Big Data Research and Development Strategic Plan](https://www.whitehouse.gov/sites/default/files/microsites/ostp/NSTC/bigdatardstrategicplan-nitrd_final-051916.pdf) outlines a vision where cooperation between the public and private sectors leads to innovation in government. It envisions real-time, diverse datasets being used to reduce traffic congestion, increase energy efficiency, and reduce fraud and waste for the American public.
 
-Our projects involve just the type of public-private cooperation that the strategic plan imagines --- improving access, discoverability, and usability of government research and data. We can build a new products and services, working to improve them continuously, until they meet project needs.
+Our projects involve just the type of public-private cooperation that the strategic plan imagines --- improving access, discoverability, and usability of government research and data. We can build new products and services, working to improve them continuously, until they meet project needs.
 
 
 ### Our process

--- a/our_work/index.md
+++ b/our_work/index.md
@@ -16,11 +16,11 @@ Our projects involve just the type of public-private cooperation that the strate
 
 ### Our process
 
-Our process begins with you. Our team works fast, in the open, and with Joint Venture Partners. Together we'll build a new product or service. We'll work with you to continuously improve it until it meets your needs. 
+Our process begins with you. Our team works fast, in the open, and with Joint Venture Partners. Together we'll build a new product or service, working continuously to improve it until it meets the prjoect's needs. 
 
-For agencies, the process looks something like this:
+For federal agencies, the process looks something like this:
 
-1. You identify a need, and we review it. We start to identify partners.
+1. Your agency identifies a need, and we review it. We start to identify partners.
 2. We work with you to develop objectives and evaluation criteria.
 3. We work with our partners prepare a response to the objectives and evaluation criteria. This can include oral presentations and demonstrations.
 4. We present the project to our advisory board.  If approved, we notify your team and develop a project plan.

--- a/our_work/index.md
+++ b/our_work/index.md
@@ -11,19 +11,19 @@ With the support of industry experts, we help federal agencies manage data and c
 
 The [Federal Big Data Research and Development Strategic Plan](https://www.whitehouse.gov/sites/default/files/microsites/ostp/NSTC/bigdatardstrategicplan-nitrd_final-051916.pdf) outlines a vision where cooperation between the public and private sectors leads to innovation in government. It envisions real-time, diverse datasets being used to reduce traffic congestion, increase energy efficiency, and reduce fraud and waste for the American public.
 
-Our projects involve just the type of public-private cooperation that the strategic plan imagines --- improving access, discoverability, and usability of government research and data.
+Our projects involve just the type of public-private cooperation that the strategic plan imagines --- improving access, discoverability, and usability of government research and data. We can build a new products and services, working to improve them continuously, until they meet project needs.
 
 
 ### Our process
 
-Our process begins with you. Our team works fast, in the open, and with Joint Venture Partners. Together we'll build a new product or service, working continuously to improve it until it meets the prjoect's needs. 
+Our process begins with you. Our team works fast, in the open, and with Joint Venture Partners. 
 
 For federal agencies, the process looks something like this:
 
 1. Your agency identifies a need, and we review it. We start to identify partners.
 2. We work with you to develop objectives and evaluation criteria.
 3. We work with our partners prepare a response to the objectives and evaluation criteria. This can include oral presentations and demonstrations.
-4. We present the project to our advisory board.  If approved, we notify your team and develop a project plan.
+4. We present the project to our advisory board. If approved, we notify your team and develop a project plan.
 5. Paperwork is signed, and funds are obligated. Work begins.
 
 Do you have a project in mind? <a href="mailto:info@ntis.gov?Subject=Project%20Inquiry" target="_top">Reach out to us</a>. We'll respond within 24 hours.


### PR DESCRIPTION
I know I'm coming in under the wire; abject pleading apologies. But I think these last refinements will really make the content better all around. 

On the "**Home**" I:
- renamed"Partner with us section" which is duplicative of main nav item (and thus confusing). It's retitled "Who we work with"
- tweaked  the footer language. It doesn't mirror the top nav anymore, but it's easier to read this way. I think it's better unless someone else has a strong objection

On the "**About**" page: We talked about providing things before they come to market twice. We really only need that information in one place. Repeating it makes it look like we've run out of things to say, and we definitely don't want to give that impression on a microsite.

The "**Process**" section needed to address both gov and private-sector folks, so I took out an ambiguous "your" that could impact understandability of content

On the "**Our work**" page I tweaked the language again to avoid pronoun ambiguity. I moved one sentence from "Process" to "What we do" because the process section had gotten quite long and hard to scan.

cc @OpenGlobe @femmebot @robertsosinski 
